### PR TITLE
Debug google apps node runtime error

### DIFF
--- a/client/src/components/automation/AutomationBuilder.tsx
+++ b/client/src/components/automation/AutomationBuilder.tsx
@@ -457,7 +457,7 @@ export function AutomationBuilder({ automationId, onScriptGenerated }: Automatio
 
       const reactFlowBounds = reactFlowWrapper.current.getBoundingClientRect();
       const type = event.dataTransfer.getData('application/reactflow');
-      const appData = event.dataTransfer.getData('application/json');
+      const appId = event.dataTransfer.getData('application/json');
 
       if (!type) return;
 
@@ -466,11 +466,26 @@ export function AutomationBuilder({ automationId, onScriptGenerated }: Automatio
         y: event.clientY - reactFlowBounds.top,
       });
 
+      let nodeData = {};
+      
+      // For googleApp type, find the original app data to preserve React components
+      if (type === 'googleApp' && appId) {
+        const parsedData = JSON.parse(appId);
+        const originalApp = googleApps.find(app => app.id === parsedData.id);
+        nodeData = originalApp || parsedData;
+      } else if (type === 'trigger' && appId) {
+        const parsedData = JSON.parse(appId);
+        const originalTrigger = triggerTypes.find(trigger => trigger.id === parsedData.id);
+        nodeData = originalTrigger || parsedData;
+      } else if (appId) {
+        nodeData = JSON.parse(appId);
+      }
+
       const newNode: Node = {
         id: `${type}-${Date.now()}`,
         type,
         position,
-        data: appData ? JSON.parse(appData) : {},
+        data: nodeData,
       };
 
       setNodes((nds) => nds.concat(newNode));

--- a/client/src/components/automation/nodes/GoogleAppsNode.tsx
+++ b/client/src/components/automation/nodes/GoogleAppsNode.tsx
@@ -51,7 +51,7 @@ export function GoogleAppsNode({ data, id }: NodeProps<GoogleAppsNodeData>) {
               {Icon && typeof Icon === 'function' ? (
                 <Icon className="w-5 h-5" style={{ color: data.color }} />
               ) : (
-                <div className="w-5 h-5 rounded bg-gray-300" style={{ backgroundColor: data.color }} />
+                <div className="w-5 h-5 rounded bg-gray-300" style={{ backgroundColor: data.color || '#6B7280' }} />
               )}
               <CardTitle className="text-sm">{data.name}</CardTitle>
             </div>
@@ -93,7 +93,11 @@ export function GoogleAppsNode({ data, id }: NodeProps<GoogleAppsNodeData>) {
             <CardHeader>
               <div className="flex items-center justify-between">
                 <CardTitle className="flex items-center gap-2">
-                  <Icon className="w-5 h-5" style={{ color: data.color }} />
+                  {Icon && typeof Icon === 'function' ? (
+                    <Icon className="w-5 h-5" style={{ color: data.color }} />
+                  ) : (
+                    <div className="w-5 h-5 rounded bg-gray-300" style={{ backgroundColor: data.color || '#6B7280' }} />
+                  )}
                   Configure {data.name}
                 </CardTitle>
                 <Button

--- a/client/src/components/automation/nodes/TriggerNode.tsx
+++ b/client/src/components/automation/nodes/TriggerNode.tsx
@@ -44,7 +44,11 @@ export function TriggerNode({ data }: NodeProps<TriggerNodeData>) {
         
         <CardContent className="pt-0">
           <div className="flex items-center gap-2 mb-2">
-            <Icon className="w-4 h-4 text-green-600" />
+            {Icon && typeof Icon === 'function' ? (
+              <Icon className="w-4 h-4 text-green-600" />
+            ) : (
+              <div className="w-4 h-4 rounded bg-green-300" />
+            )}
             <div className="font-medium text-sm">{data.name}</div>
           </div>
           <div className="text-xs text-gray-600">
@@ -62,7 +66,11 @@ export function TriggerNode({ data }: NodeProps<TriggerNodeData>) {
             <CardHeader>
               <div className="flex items-center justify-between">
                 <CardTitle className="flex items-center gap-2">
-                  <Icon className="w-5 h-5 text-green-600" />
+                  {Icon && typeof Icon === 'function' ? (
+                    <Icon className="w-5 h-5 text-green-600" />
+                  ) : (
+                    <div className="w-5 h-5 rounded bg-green-300" />
+                  )}
                   Configure {data.name}
                 </CardTitle>
                 <Button


### PR DESCRIPTION
Fixes "Element type is invalid" error by preserving React component icons during drag-and-drop serialization.

The error occurred because React component functions (icons) were lost when node data was `JSON.stringify`'d and `JSON.parse`'d during drag-and-drop operations. This PR modifies the `onDrop` handler to retrieve the original app/trigger data, ensuring the icon components are correctly passed, and adds safety checks for icon rendering in `GoogleAppsNode` and `TriggerNode`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fc08bae-0440-4962-b78d-1b13d7bfa569">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2fc08bae-0440-4962-b78d-1b13d7bfa569">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

